### PR TITLE
解决同个分组，同个方法，不同控制器，左侧菜单方法显示不全的问题

### DIFF
--- a/src/Utility/AnnotationDoc.php
+++ b/src/Utility/AnnotationDoc.php
@@ -126,6 +126,11 @@ class AnnotationDoc
             $methods = $objectAnnotation->getMethod();
             ksort($methods);
             $controllerAnnotation = $objectAnnotation->getController();
+			if(!$controllerAnnotation){
+                $controllerName = 'default';
+            }else{
+                $controllerName = $controllerAnnotation->value;
+            }
             foreach ($methods as $methodName => $method) {
                 //仅仅渲染有api标记的方法
                 $apiTag = $method->getApiTag();
@@ -135,12 +140,12 @@ class AnnotationDoc
                         $globalInfo = '';
                     }
 
-                    $groupList[$currentGroupName][$method->getMethodName()] = $method;
+                    $groupList[$currentGroupName][$controllerName.'-'.$method->getMethodName()] = $method;
                     $deprecated = '';
                     if ($apiTag->deprecated) {
                         $deprecated .= "<sup class='deprecated'>已废弃</sup>";
                     }
-                    $html .= "<h2 class='api-method {$currentGroupName}' id='{$currentGroupName}-{$methodName}'>{$apiTag->name}{$deprecated}</h2>{$this->CLRF}";
+                    $html .= "<h2 class='api-method {$currentGroupName}' id='{$currentGroupName}-{$controllerName}-{$methodName}'>{$apiTag->name}{$deprecated}</h2>{$this->CLRF}";
 
                     $html .= "<h3 class='method-description'>基本信息</h3>{$this->CLRF}";
                     //兼容api指定


### PR DESCRIPTION
项目API结构：
![image](https://user-images.githubusercontent.com/16120893/138054384-1a5338de-7445-4168-9e11-0c21d93b2b4e.png)

其中：Wechat文件夹下面的两个类，Login.php和Register.php，同个分组，
请求接口分别是：
登录：/api/wechat/login/index
注册：/api/wechat/register/index
文件代码节选：
`/**
 * Class Register
 * @Controller("Register")
 * @package App\HttpController\Api\Wechat
 * @ApiGroup(groupName="微信小程序")
 * @ApiGroupDescription("微信小程序相关")
 */
class Register extends Base
{

    /**
     * @Api(name="小程序用户注册",path="/api/wechat/register")
     * @ApiDescription("微信小程序用户注册")
     * @Method(allow={POST})
     * @Param(name="openid",type="string",required="",description="OPENID")
     * @Param(name="username",type="string",required="",description="用户昵称")
     * @Param(name="sex",type="int",required="",description="性别 0男1女")
     * @Param(name="companyID",type="int",required="",description="物流公司ID")
     * @ApiSuccess(
    {
    "code": 200,
    "result": {
            1
    },
    "msg": "ok"
    }
    )
     * @ApiFail(
    {
    "code": 600,
    "result": {
        "error": "openid:openid不能为空!"
    },
    "msg": "openid:openid不能为空!"
    }
    )
     */


    public function index(){
        $params = $this->_params;
        $Val = new Validator($this->_params);
        $Val->rule('required', 'companyID')->message('物流公司ID不能为空!')
            ->rule('required', 'username')->message('用户昵称不能为空!')
            ->rule('required', 'sex')->message('用户性别不能为空!')
            ->rule('required', 'openid')->message('openid不能为空!');

        if(!$Val->validate()) {
            $msg = [];
            foreach ($Val->errors() as $k=>$v){
                $msg[] = $k.':'.implode('|',$v);
            }
            $msg = implode(',',$msg);
            return $this->writeJson(
                600,
                ['error' => $msg],
                $msg
            );
        }
        $wx = new AppletUser();
        $res = $wx->register($params);
        if($res){
            return $this->writeJson(
                200,
                $res,
                'ok'
            );
        }else {
            return $this->writeJson(
                600,
                ['error' => $wx->getError()],
                $wx->getError()
            );
        }


    }

}`
`/**
 * class Login
 * @Controller("Login")
 * @package App\HttpController\Api\Wechat
 * @ApiGroup(groupName="微信小程序")
 * @ApiGroupDescription("微信小程序相关")
 */
class Login extends Base
{

    /**
     * @Api(name="小程序用户登录",path="/api/wechat/login")
     * @ApiDescription("微信小程序用户登录")
     * @ApiRequestExample("curl -X POST -d  http://127.0.0.1:9502/api/wechat/login")
     * @Method(allow={POST})
     * @Param(name="code",type="string",required="required",description="小程序wx.login()获取的code")
     * @ApiSuccess(
    {
    "code": 600,
    "result": {
    "error": "code:CODE不能为空!"
    },
    "msg": "code:CODE不能为空!"
    }
      )
     * @ApiFail(
    {
    "code": 600,
    "result": {
    "error": "缺少code参数"
    },
    "msg": "缺少code参数"
    }
     )
     */


    public function index(){

        $params = $this->_params;
        $Val = new Validator($this->_params);
        $Val->rule('required', 'code')->message('CODE不能为空!');
        if(!$Val->validate()) {
            $msg = [];
            foreach ($Val->errors() as $k=>$v){
                $msg[] = $k.':'.implode('|',$v);
            }
            $msg = implode(',',$msg);
            return $this->writeJson(
                600,
                ['error' => $msg],
                $msg
            );
        }
        $wx = new AppletUser();
        $res = $wx->login($params);
        if($res){
            return $this->writeJson(
                200,
                $res,
                'ok'
            );
        }else {
            return $this->writeJson(
                600,
                ['error' => $wx->getError()],
                $wx->getError()
            );
        }

    }

}`

API在同个分组，里面请求的同个方法名，但是不同的类里面
最后导致，doc文档左侧菜单只显示一个函数。（easyswoole6群：524475224  有我发的消息截图，此处由于网络问题无法上传图片）

根据分析，我找到对应的方法只需要加上控制器名字进行区分方法，这样就可以避免。
### 获取控制器名字，且判断是否有配置@controller，如果没有则给他一个默认default
EasySwoole\HttpAnnotation\Utility\AnnotationDoc
line:128行
`$controllerAnnotation = $objectAnnotation->getController();
            if(!$controllerAnnotation){
                $controllerName = 'default';
            }else{
                $controllerName = $controllerAnnotation->value;
            }`
line:143行
`$groupList[$currentGroupName][$controllerName.'-'.$method->getMethodName()] = $method;`
line: 148行 标记ID锚点
`$html .= "<h2 class='api-method {$currentGroupName}' id='{$currentGroupName}-{$controllerName}-{$methodName}'>{$apiTag->name}{$deprecated}</h2>{$this->CLRF}";`
